### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "gemmlowp"
+description := "Low-precision matrix multiplication."
+gitrepo     := "https://github.com/google/gemmlowp.git"
+homepage    := "https://github.com/google/gemmlowp/"
+version     := 12fed0c sha256:ab3873363ed63cd0090bd4e59dc29e63ecce9d84e66093083e5fda2cac14e74b https://github.com/google/gemmlowp/archive/12fed0c.tar.gz
+license     := "Apache-2.0"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

